### PR TITLE
Enable media cleanup

### DIFF
--- a/Model/Handler/Media.php
+++ b/Model/Handler/Media.php
@@ -181,7 +181,7 @@ class Media extends AbstractFiles implements HandlerInterface
         $currentPath    = $path;
 
         for ($level = $depth; $level >= 0; $level --) {
-            if (empty($pathParts[$level]) == false) {
+            if (isset($pathParts[$level]) && $pathParts[$level] != '') {
                 if (empty($this->directoryHashMap[$level][$currentPath]) == true) {
                     $this->directoryHashMap[$level][$currentPath] = $fileCount;
                 } else {

--- a/Model/Handler/Media.php
+++ b/Model/Handler/Media.php
@@ -139,7 +139,7 @@ class Media extends AbstractFiles implements HandlerInterface
         //output the savings in bytes
         $bytesFormatted = $this->helper->getBytesFormatted($this->sizeCount, 2);
         $this->logger->info(
-            'saved: ' . number_format($this->sizeCount, 0, ',', '.') . ' Bytes (' . $bytesFormatted . ')'
+            'moved to recycle bin: ' . number_format($this->sizeCount, 0, ',', '.') . ' Bytes (' . $bytesFormatted . ')'
         );
 
         return $this;
@@ -339,6 +339,7 @@ class Media extends AbstractFiles implements HandlerInterface
                         copy($file, $newFilePath);
 
                         //delete the original file
+                        $this->calculateSavings($file);
                         $this->log('deleting: ' . $file);
                         unlink($file);
                     } catch (Exception $e) {

--- a/Model/Handler/Media.php
+++ b/Model/Handler/Media.php
@@ -200,8 +200,8 @@ class Media extends AbstractFiles implements HandlerInterface
         //do recursive call
         if (empty($directories) == false) {
             foreach ($directories as $directory) {
-                //ignore cache and placeholder
-                if ($directory != $this->cachePath && $directory != $this->placeholderPath && $directory != $this->watermarkPath) {
+                //ignore placeholder and watermark
+                if ($directory != $this->placeholderPath && $directory != $this->watermarkPath) {
                     $this->detectEmptyFolders($directory);
                 }
             }
@@ -216,7 +216,7 @@ class Media extends AbstractFiles implements HandlerInterface
         $this->detectEmptyFolders($this->magentoMediaPath);
 
         //delete the empty folders
-        $depth = count($this->directoryHashMap);
+        $depth = !empty($this->directoryHashMap) ? max(array_keys($this->directoryHashMap)) : 0;
         for ($level = $depth; $level >= 0; $level --) {
             if (empty($this->directoryHashMap[$level]) == false) {
                 foreach ($this->directoryHashMap[$level] as $directory => $fileCount) {

--- a/Model/Handler/Media.php
+++ b/Model/Handler/Media.php
@@ -14,7 +14,14 @@
 namespace Phoenix\Cleanup\Model\Handler;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Archive;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Io\File;
 use Phoenix\Cleanup\Api\HandlerInterface;
+use Phoenix\Cleanup\Helper\Data as Helper;
+use Phoenix\Cleanup\Logger\Logger;
+use Phoenix\Cleanup\Model\Config;
 
 class Media extends AbstractFiles implements HandlerInterface
 {
@@ -74,6 +81,25 @@ class Media extends AbstractFiles implements HandlerInterface
      */
     protected $directoryHashMap = [];
 
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Config $config,
+        Logger $logger,
+        Helper $helper,
+        Filesystem $filesystem,
+        DirectoryList $directoryList,
+        Archive $archive,
+        File $io
+    ) {
+        parent::__construct($config, $logger, $helper, $filesystem, $directoryList, $archive, $io);
+
+        $this->resourceConnection = $resourceConnection;
+    }
 
     /**
      * Returns is configuration allowed execution
@@ -216,7 +242,7 @@ class Media extends AbstractFiles implements HandlerInterface
     {
         $this->log('checking database');
 
-        /* @var $resource Mage_Core_Model_Resource */
+        /* @var ResourceConnection $resource */
         $resource   = $this->resourceConnection;
         $connection = $resource->getConnection('core_read');
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,7 +19,7 @@
                 <item name="logFiles" xsi:type="string">Phoenix\Cleanup\Model\Handler\FilesLogs</item>
                 <item name="reportFiles" xsi:type="string">Phoenix\Cleanup\Model\Handler\FilesReports</item>
                 <item name="optionalFolder" xsi:type="string">Phoenix\Cleanup\Model\Handler\FilesFolders</item>
-                <!--item name="media" xsi:type="string">Phoenix\Cleanup\Model\Handler\Media</item-->
+                <item name="media" xsi:type="string">Phoenix\Cleanup\Model\Handler\Media</item>
                 <item name="customerQuotes" xsi:type="string">Phoenix\Cleanup\Model\Handler\QuotesCustomer</item>
                 <item name="guestQuotes" xsi:type="string">Phoenix\Cleanup\Model\Handler\QuotesGuest</item>
                 <item name="adminNotification" xsi:type="string">Phoenix\Cleanup\Model\Handler\AdminNotifications</item>


### PR DESCRIPTION
Tested and fixed media cleanup script.
The resource connection wasn't migrated to Magento 2 yet, which is fixed now and for the logging the saved file size is calculated and logged as size moved to recylce bin, as the archive cleanup doesn't calculate the filesize because it's a directory deletion.

Cache folder is no longer ignored but also cleaned from files that are no longer assigned to a product. Further empty cache folders will be cleaned as well.