### PR TITLE
Run cleanup cron in separate process

### DIFF
--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="phoenix_cleanup_magento">
+        <schedule_generate_every>15</schedule_generate_every>
+        <schedule_ahead_for>20</schedule_ahead_for>
+        <schedule_lifetime>15</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>4320</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>
+

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="phoenix_cleanup_magento">
         <job name="phoenix_cleanup_magento" instance="Phoenix\Cleanup\Model\Cron" method="execute">
             <config_path>crontab/default/jobs/phoenix_cleanup_magento/schedule/cron_expr</config_path>
         </job>


### PR DESCRIPTION
Introduce separate cron group for the PHOENIX MEDIA Cleanup cron job to
run it in a separate process.