### PR TITLE
Feature: Add option to skip given amount of days in optional folder cleanup

### DIFF
--- a/Block/Adminhtml/System/Config/Fieldset/Folders.php
+++ b/Block/Adminhtml/System/Config/Fieldset/Folders.php
@@ -32,6 +32,14 @@ class Folders extends AbstractFieldArray
         );
 
         $this->addColumn(
+            'skip_days',
+            [
+                'label' => __('Skip Days'),
+                'style' => 'width:80px'
+            ]
+        );
+
+        $this->addColumn(
             'days',
             [
                 'label' => __('Cleanup Days'),

--- a/Model/Handler/FilesFolders.php
+++ b/Model/Handler/FilesFolders.php
@@ -65,8 +65,9 @@ class FilesFolders extends AbstractFiles implements HandlerInterface
                 }
                 $currentArchive .= DIRECTORY_SEPARATOR;
 
+                $skipDays = array_key_exists('skip_days', $folder) ? (int)$folder['skip_days'] : 0;
                 //check if there are any files
-                $files = $this->getFileList($pathToCleanup, $folder['mask']);
+                $files = $this->getFileList($pathToCleanup, $folder['mask'], $skipDays);
                 $this->log('cleaning up ' . count($files) . ' files in optional path: ' . $folder['path']);
 
                 foreach ($files as $file) {

--- a/Model/Handler/Media.php
+++ b/Model/Handler/Media.php
@@ -14,6 +14,7 @@
 
 namespace Phoenix\Cleanup\Model\Handler;
 
+use DateTime;
 use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ResourceConnection;
@@ -98,9 +99,10 @@ class Media extends AbstractFiles implements HandlerInterface
         Filesystem $filesystem,
         DirectoryList $directoryList,
         Archive $archive,
-        File $io
+        File $io,
+        DateTime $dateTime
     ) {
-        parent::__construct($config, $logger, $helper, $filesystem, $directoryList, $archive, $io);
+        parent::__construct($config, $logger, $helper, $filesystem, $directoryList, $archive, $io, $dateTime);
 
         $this->resourceConnection = $resourceConnection;
     }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "ext-zlib": "*"
     },
     "type": "magento2-module",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "license": "MIT",
     "autoload": {
         "files": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -81,7 +81,9 @@
                 </field>
                 <field id="cleanup_optional_folders" translate="label comment" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Optional Folders</label>
-                    <comment>Add additional folders to the cleanup process. Path is relative within magento base directory</comment>
+                    <comment>
+                        <![CDATA[Add additional folders to the cleanup process. Path is relative within magento base directory.<br/>"Skip Days" defines how many days shouldn't be archived yet.<br/>"Cleanup Days" defines the number of days which the files are stored in archive before final cleanup.]]>
+                    </comment>
                     <frontend_model>Phoenix\Cleanup\Block\Adminhtml\System\Config\Fieldset\Folders</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                     <depends>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Phoenix_Cleanup" setup_version="1.0.3">
+    <module name="Phoenix_Cleanup" setup_version="1.0.4">
         <sequence/>
     </module>
 </config>


### PR DESCRIPTION
To meet a customers requirement we need the possibility to configure an amount of days that files should be ignored on cleanup in additional folders. The new field "Skip days" will only archive files older than that amount of days (by modification date).